### PR TITLE
feat: add paper generation frontend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+build/
+dist/
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# pagegenerate
+# 论文生成助手（Paper Generator）
+
+一个基于 React + TypeScript 的前端应用，通过调用 Dify API 自动生成论文大纲与正文，并提供标题建议、错误提示与恢复建议。
+
+## 功能概述
+
+- **论文大纲生成**：根据题目、专业、研究方向、字数与补充说明调用 Dify 工作流生成大纲。
+- **标题建议**：输入种子主题后获取多个备选标题，便于快速确定论文题目。
+- **论文正文生成**：确认或编辑大纲后触发正文生成流程，支持长文本写作。
+- **错误提示与恢复**：对网络异常、超时、鉴权失败等情况提供清晰的中文提示。
+- **帮助中心**：提供快速上手指南与常见问题解答，降低使用门槛。
+
+## 目录结构
+
+```
+├── public/                # CRA 静态资源
+├── src/
+│   ├── components/
+│   │   └── OutlineEditor/ # 通用大纲编辑器组件
+│   ├── pages/
+│   │   ├── Generate/      # 论文生成页
+│   │   └── Help/          # 使用帮助页
+│   ├── services/
+│   │   └── difyApi.ts     # Dify API 封装与错误处理
+│   ├── styles/            # 全局样式
+│   ├── App.tsx            # 应用主入口
+│   ├── index.tsx          # React 渲染入口
+│   ├── setupProxy.js      # 本地开发代理：/v1 -> https://api.dify.ai
+│   ├── setupTests.ts      # 测试初始化
+│   └── App.test.tsx       # 基础渲染测试
+├── package.json
+└── tsconfig.json
+```
+
+## 本地开发
+
+```bash
+npm install
+npm start
+```
+
+默认端口为 `3000`。如需自定义端口，可在启动前设置 `PORT` 环境变量。
+
+### 代理说明
+
+开发环境下，`src/setupProxy.js` 会将前端发往 `/v1/*` 的请求转发到 `https://api.dify.ai/v1`，并将超时设置为 10 分钟，以缓解长流程导致的 504 问题。
+
+## 生产建议
+
+- 若任务耗时较长，建议改造为 **SSE 流式输出** 或 **异步提交 + 结果轮询**，提升稳定性。
+- 在生产环境中不要暴露 Dify API Key，可通过后端代理或 BFF 层统一管理密钥。
+- 对关键调用增加监控与日志，记录失败类型、请求耗时与重试次数。
+
+## 测试
+
+```bash
+npm test
+```
+
+该命令会以非 watch 模式运行 React Testing Library 提供的单元测试。

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "pagegenerate",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@ant-design/icons": "^6.0.2",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.1",
+    "antd": "^5.27.3",
+    "axios": "^1.12.2",
+    "http-proxy-middleware": "^3.0.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.9.1",
+    "react-scripts": "5.0.1",
+    "web-vitals": "^4.2.4"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.12.12",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@types/react-router-dom": "^5.3.3",
+    "typescript": "^4.9.5"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --watch=false",
+    "eject": "react-scripts eject"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="论文大纲与正文生成助手"
+    />
+    <title>论文生成助手</title>
+  </head>
+  <body>
+    <noscript>需要启用 JavaScript 才能运行该应用。</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,9 @@
+{
+  "short_name": "论文助手",
+  "name": "论文大纲与正文生成助手",
+  "icons": [],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#1677ff",
+  "background_color": "#ffffff"
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import App from './App';
+
+describe('App', () => {
+  it('renders generate page link', () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('生成论文')).toBeInTheDocument();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,63 @@
+import { FileTextOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { Layout, Menu, Typography } from 'antd';
+import React from 'react';
+import { Link, Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import GeneratePage from './pages/Generate';
+import HelpPage from './pages/Help';
+
+const { Header, Content, Footer } = Layout;
+
+const App: React.FC = () => {
+  const location = useLocation();
+  const selectedKeys = React.useMemo(() => {
+    if (location.pathname.startsWith('/help')) {
+      return ['help'];
+    }
+    if (location.pathname.startsWith('/generate')) {
+      return ['generate'];
+    }
+    return [];
+  }, [location.pathname]);
+
+  return (
+    <Layout className="app-layout">
+      <Header className="app-header">
+        <Typography.Title level={4} className="app-logo">
+          论文生成助手
+        </Typography.Title>
+        <Menu
+          theme="dark"
+          mode="horizontal"
+          selectedKeys={selectedKeys}
+          items={[
+            {
+              key: 'generate',
+              icon: <FileTextOutlined />,
+              label: <Link to="/generate">生成论文</Link>
+            },
+            {
+              key: 'help',
+              icon: <QuestionCircleOutlined />,
+              label: <Link to="/help">使用帮助</Link>
+            }
+          ]}
+        />
+      </Header>
+      <Content className="app-content">
+        <Routes>
+          <Route path="/" element={<Navigate to="/generate" replace />} />
+          <Route path="/generate" element={<GeneratePage />} />
+          <Route path="/help" element={<HelpPage />} />
+          <Route path="*" element={<Navigate to="/generate" replace />} />
+        </Routes>
+      </Content>
+      <Footer className="app-footer">
+        <Typography.Text type="secondary">
+          © {new Date().getFullYear()} 论文生成助手 · 基于 Dify API 构建
+        </Typography.Text>
+      </Footer>
+    </Layout>
+  );
+};
+
+export default App;

--- a/src/components/OutlineEditor/index.tsx
+++ b/src/components/OutlineEditor/index.tsx
@@ -1,0 +1,47 @@
+import { SaveOutlined } from '@ant-design/icons';
+import { Button, Input, Space, Typography } from 'antd';
+import React from 'react';
+
+type OutlineEditorProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit?: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+};
+
+const OutlineEditor: React.FC<OutlineEditorProps> = ({
+  value,
+  onChange,
+  onSubmit,
+  disabled,
+  loading
+}) => {
+  return (
+    <Space direction="vertical" size="middle" className="full-width">
+      <Typography.Text type="secondary">
+        生成的大纲可在此处进行修改。调整后点击“保存编辑”以用于后续正文生成。
+      </Typography.Text>
+      <Input.TextArea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        autoSize={{ minRows: 12, maxRows: 24 }}
+        disabled={disabled}
+        placeholder="请输入或编辑论文大纲..."
+      />
+      {onSubmit && (
+        <Button
+          type="primary"
+          icon={<SaveOutlined />}
+          onClick={onSubmit}
+          disabled={disabled}
+          loading={loading}
+        >
+          保存编辑
+        </Button>
+      )}
+    </Space>
+  );
+};
+
+export default OutlineEditor;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import 'antd/dist/reset.css';
+import './styles/global.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('未找到根节点 #root');
+}
+
+const root = ReactDOM.createRoot(rootElement);
+
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/Generate/index.tsx
+++ b/src/pages/Generate/index.tsx
@@ -1,0 +1,418 @@
+import {
+  BulbOutlined,
+  CheckCircleOutlined,
+  CloudDownloadOutlined,
+  FileTextOutlined,
+  KeyOutlined,
+  RedoOutlined
+} from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Divider,
+  Form,
+  Input,
+  InputNumber,
+  List,
+  message,
+  Row,
+  Space,
+  Spin,
+  Tag,
+  Typography
+} from 'antd';
+import React from 'react';
+import OutlineEditor from '../../components/OutlineEditor';
+import {
+  fetchTitleSuggestions,
+  formatErrorMessage,
+  generatePaperContent,
+  generatePaperOutline,
+  validateApiKey
+} from '../../services/difyApi';
+
+const { Title, Paragraph, Text } = Typography;
+
+interface GenerateFormValues {
+  title: string;
+  major?: string;
+  direction?: string;
+  wordCount?: number;
+  description?: string;
+}
+
+type LoadingState = {
+  outline: boolean;
+  content: boolean;
+  suggestions: boolean;
+  validateKey: boolean;
+  saveOutline: boolean;
+};
+
+const initialLoadingState: LoadingState = {
+  outline: false,
+  content: false,
+  suggestions: false,
+  validateKey: false,
+  saveOutline: false
+};
+
+const GeneratePage: React.FC = () => {
+  const [form] = Form.useForm<GenerateFormValues>();
+  const [loading, setLoading] = React.useState(initialLoadingState);
+  const [outline, setOutline] = React.useState('');
+  const [editedOutline, setEditedOutline] = React.useState('');
+  const [content, setContent] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+  const [suggestions, setSuggestions] = React.useState<string[]>([]);
+  const [apiKey, setApiKey] = React.useState('');
+  const [apiKeyStatus, setApiKeyStatus] = React.useState<'idle' | 'valid' | 'invalid'>('idle');
+
+  const updateLoading = React.useCallback((partial: Partial<LoadingState>) => {
+    setLoading((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const handleGenerateOutline = React.useCallback(async () => {
+    setError(null);
+    const values = await form.validateFields(['title', 'major', 'direction', 'wordCount', 'description']);
+    updateLoading({ outline: true });
+    try {
+      const outlineText = await generatePaperOutline(
+        {
+          title: values.title,
+          major: values.major,
+          direction: values.direction,
+          wordCount: values.wordCount,
+          description: values.description
+        },
+        apiKey
+      );
+      setOutline(outlineText);
+      setEditedOutline(outlineText);
+      setContent('');
+      message.success('已生成论文大纲');
+    } catch (err) {
+      const formatted = formatErrorMessage(err);
+      setError(formatted);
+      message.error(formatted);
+    } finally {
+      updateLoading({ outline: false });
+    }
+  }, [apiKey, form, updateLoading]);
+
+  const handleSaveOutline = React.useCallback(async () => {
+    if (!editedOutline) {
+      message.warning('请先完善大纲内容');
+      return;
+    }
+    updateLoading({ saveOutline: true });
+    try {
+      setOutline(editedOutline);
+      message.success('大纲已保存，可用于生成正文');
+    } finally {
+      updateLoading({ saveOutline: false });
+    }
+  }, [editedOutline, updateLoading]);
+
+  const handleGenerateContent = React.useCallback(async () => {
+    setError(null);
+    const values = form.getFieldsValue();
+    if (!editedOutline) {
+      message.warning('请先生成并确认大纲');
+      return;
+    }
+    updateLoading({ content: true });
+    try {
+      const contentText = await generatePaperContent(
+        {
+          outline: editedOutline,
+          wordCount: values.wordCount
+        },
+        apiKey
+      );
+      setContent(contentText);
+      message.success('正文生成完成');
+    } catch (err) {
+      const formatted = formatErrorMessage(err);
+      setError(formatted);
+      message.error(formatted);
+    } finally {
+      updateLoading({ content: false });
+    }
+  }, [apiKey, editedOutline, form, updateLoading]);
+
+  const handleFetchSuggestions = React.useCallback(async () => {
+    const { title: seedText } = await form.validateFields(['title']);
+    setError(null);
+    updateLoading({ suggestions: true });
+    try {
+      const result = await fetchTitleSuggestions(seedText, apiKey);
+      setSuggestions(result);
+      if (result.length === 0) {
+        message.info('未获取到更多标题建议，可尝试修改输入');
+      } else {
+        message.success('已获取标题建议');
+      }
+    } catch (err) {
+      const formatted = formatErrorMessage(err);
+      setError(formatted);
+      message.error(formatted);
+    } finally {
+      updateLoading({ suggestions: false });
+    }
+  }, [apiKey, form, updateLoading]);
+
+  const handleValidateKey = React.useCallback(async () => {
+    if (!apiKey) {
+      message.warning('请输入要校验的 API Key');
+      return;
+    }
+    updateLoading({ validateKey: true });
+    try {
+      const valid = await validateApiKey(apiKey);
+      setApiKeyStatus(valid ? 'valid' : 'invalid');
+      if (valid) {
+        message.success('API Key 校验通过');
+      } else {
+        message.error('API Key 无效，请检查后重试');
+      }
+    } catch (err) {
+      setApiKeyStatus('invalid');
+      const formatted = formatErrorMessage(err);
+      message.error(formatted);
+    } finally {
+      updateLoading({ validateKey: false });
+    }
+  }, [apiKey, updateLoading]);
+
+  return (
+    <div className="page-container">
+      <Title level={2}>论文生成中心</Title>
+      <Paragraph type="secondary">
+        输入论文基本信息并调用 Dify 工作流自动生成大纲与正文。可在生成过程中查看错误提示与重试建议。
+      </Paragraph>
+
+      <Card title="Dify API Key（可选）" style={{ marginBottom: 24 }}>
+        <Row gutter={16} align="middle">
+          <Col xs={24} md={16}>
+            <Input.Password
+              prefix={<KeyOutlined />}
+              placeholder="输入 Dify 应用的 API Key"
+              value={apiKey}
+              onChange={(event) => {
+                setApiKey(event.target.value);
+                setApiKeyStatus('idle');
+              }}
+              autoComplete="off"
+            />
+          </Col>
+          <Col xs={24} md={8}>
+            <Space>
+              <Button
+                type="primary"
+                onClick={handleValidateKey}
+                loading={loading.validateKey}
+                icon={<CheckCircleOutlined />}
+              >
+                校验 Key
+              </Button>
+              {apiKeyStatus === 'valid' && <Tag color="success">已通过校验</Tag>}
+              {apiKeyStatus === 'invalid' && <Tag color="error">校验失败</Tag>}
+            </Space>
+          </Col>
+        </Row>
+        <Paragraph type="secondary" style={{ marginTop: 12 }}>
+          出于安全考虑，推荐在浏览器中临时输入 Key 或通过后端代理隐藏密钥。若不填写，则使用默认浏览器配置。
+        </Paragraph>
+      </Card>
+
+      <Card title="论文信息填写">
+        <Form<GenerateFormValues>
+          layout="vertical"
+          form={form}
+          initialValues={{ wordCount: 3000 }}
+        >
+          <Form.Item
+            label="论文题目"
+            name="title"
+            rules={[{ required: true, message: '请输入论文题目或主题' }]}
+          >
+            <Input placeholder="示例：基于深度学习的文本摘要生成研究" allowClear />
+          </Form.Item>
+
+          <Row gutter={16}>
+            <Col xs={24} md={12}>
+              <Form.Item label="专业" name="major">
+                <Input placeholder="示例：计算机科学与技术" allowClear />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={12}>
+              <Form.Item label="研究方向" name="direction">
+                <Input placeholder="示例：自然语言处理" allowClear />
+              </Form.Item>
+            </Col>
+          </Row>
+
+          <Row gutter={16}>
+            <Col xs={24} md={12}>
+              <Form.Item label="字数要求" name="wordCount">
+                <InputNumber
+                  className="full-width"
+                  min={500}
+                  max={20000}
+                  placeholder="请输入期望字数"
+                />
+              </Form.Item>
+            </Col>
+            <Col xs={24} md={12}>
+              <Form.Item label="补充说明" name="description">
+                <Input.TextArea
+                  placeholder="示例：需包含相关工作综述、模型设计、实验与结论"
+                  autoSize={{ minRows: 2, maxRows: 6 }}
+                  allowClear
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+
+          <Space size="middle" wrap>
+            <Button
+              type="primary"
+              icon={<FileTextOutlined />}
+              onClick={handleGenerateOutline}
+              loading={loading.outline}
+            >
+              生成大纲
+            </Button>
+            <Button
+              icon={<BulbOutlined />}
+              onClick={handleFetchSuggestions}
+              loading={loading.suggestions}
+            >
+              获取标题建议
+            </Button>
+            <Button
+              icon={<RedoOutlined />}
+              onClick={() => {
+                form.resetFields();
+                setOutline('');
+                setEditedOutline('');
+                setContent('');
+                setSuggestions([]);
+                setError(null);
+              }}
+            >
+              清空表单
+            </Button>
+          </Space>
+        </Form>
+      </Card>
+
+      {suggestions.length > 0 && (
+        <Card
+          title={
+            <Space>
+              <BulbOutlined />
+              <span>标题建议</span>
+            </Space>
+          }
+          style={{ marginTop: 24 }}
+        >
+          <List
+            dataSource={suggestions}
+            renderItem={(item) => (
+              <List.Item
+                actions={[
+                  <Button
+                    key="apply"
+                    type="link"
+                    onClick={() => form.setFieldsValue({ title: item })}
+                  >
+                    应用
+                  </Button>
+                ]}
+              >
+                <List.Item.Meta title={item} />
+              </List.Item>
+            )}
+          />
+        </Card>
+      )}
+
+      {outline && (
+        <Card
+          title={
+            <Space>
+              <FileTextOutlined />
+              <span>论文大纲</span>
+            </Space>
+          }
+          style={{ marginTop: 24 }}
+        >
+          <OutlineEditor
+            value={editedOutline}
+            onChange={setEditedOutline}
+            onSubmit={handleSaveOutline}
+            disabled={loading.outline || loading.content}
+            loading={loading.saveOutline}
+          />
+          <Divider />
+          <Space direction="vertical" size="middle" className="full-width">
+            <Typography.Text type="secondary">
+              确认大纲无误后即可生成正文。若正文生成失败，可参考错误提示进行调整。
+            </Typography.Text>
+            <Button
+              type="primary"
+              icon={<CloudDownloadOutlined />}
+              onClick={handleGenerateContent}
+              loading={loading.content}
+              disabled={loading.outline || !editedOutline}
+            >
+              生成正文
+            </Button>
+          </Space>
+        </Card>
+      )}
+
+      {error && (
+        <Alert
+          style={{ marginTop: 24 }}
+          type="error"
+          showIcon
+          message="出现错误"
+          description={error}
+        />
+      )}
+
+      {loading.content && (
+        <Card style={{ marginTop: 24 }}>
+          <Space>
+            <Spin />
+            <Text>正在生成正文，耗时可能较长，请耐心等待…</Text>
+          </Space>
+        </Card>
+      )}
+
+      {content && (
+        <Card
+          className="result-card"
+          title={
+            <Space>
+              <FileTextOutlined />
+              <span>生成正文</span>
+            </Space>
+          }
+          style={{ marginTop: 24 }}
+        >
+          <Typography.Paragraph style={{ whiteSpace: 'pre-wrap' }}>
+            {content}
+          </Typography.Paragraph>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default GeneratePage;

--- a/src/pages/Help/index.tsx
+++ b/src/pages/Help/index.tsx
@@ -1,0 +1,82 @@
+import { Alert, Card, Col, Collapse, Row, Typography } from 'antd';
+import React from 'react';
+
+const { Title, Paragraph, Text } = Typography;
+
+const HelpPage: React.FC = () => {
+  return (
+    <div className="page-container">
+      <Title level={2}>使用帮助</Title>
+      <Paragraph>
+        本页面汇总了论文生成助手的使用方法、常见问题以及网络错误的排查建议，帮助你快速定位问题并完成论文内容的生成。
+      </Paragraph>
+
+      <Row gutter={[24, 24]}>
+        <Col xs={24} lg={16}>
+          <Card title="快速上手">
+            <Paragraph>
+              1. 在“生成论文”页面填写论文题目、专业、研究方向、字数等信息后点击“生成大纲”。
+            </Paragraph>
+            <Paragraph>
+              2. 在大纲编辑器中根据需要调整大纲结构，点击“保存编辑”确认。
+            </Paragraph>
+            <Paragraph>
+              3. 点击“生成正文”触发工作流生成论文正文，耐心等待生成完成。
+            </Paragraph>
+            <Paragraph>
+              4. 若需要更多标题灵感，可使用“获取标题建议”功能获取多个候选题目。
+            </Paragraph>
+          </Card>
+        </Col>
+        <Col xs={24} lg={8}>
+          <Card title="关键提醒">
+            <Paragraph>
+              <Text strong>安全性：</Text> 建议在临时环境中输入 API Key，或由后端代理完成调用，避免密钥泄露。
+            </Paragraph>
+            <Paragraph>
+              <Text strong>长耗时任务：</Text> 若生成正文耗时较长，可考虑改为流式模式或异步轮询。
+            </Paragraph>
+            <Paragraph>
+              <Text strong>重试策略：</Text> 若发生 504 或网络波动，可稍后重试，或减少输入内容优化请求耗时。
+            </Paragraph>
+          </Card>
+        </Col>
+      </Row>
+
+      <Card title="常见问题" style={{ marginTop: 24 }}>
+        <Collapse accordion>
+          <Collapse.Panel header="为何会提示 API Key 校验失败？" key="1">
+            <Paragraph>
+              请确认输入的 Key 对应 Dify 应用的类型与权限一致，并确保未包含多余空格。若仍失败，可尝试通过后端校验接口验证。
+            </Paragraph>
+          </Collapse.Panel>
+          <Collapse.Panel header="生成正文时报错 504/超时怎么办？" key="2">
+            <Paragraph>
+              504 通常表示任务耗时过长，建议缩减字数、拆分章节或改用流式输出模式。也可以采用“提交任务 + 轮询结果”的方式规避超时。
+            </Paragraph>
+          </Collapse.Panel>
+          <Collapse.Panel header="如何处理网络或 CORS 错误？" key="3">
+            <Paragraph>
+              请确认本地开发代理 <Text code>/v1/*</Text> 是否生效，以及浏览器是否拦截了跨域请求。必要时可在开发工具中查看网络日志进行排查。
+            </Paragraph>
+          </Collapse.Panel>
+          <Collapse.Panel header="是否支持导出生成的内容？" key="4">
+            <Paragraph>
+              当前版本可复制文本内容到本地文档，后续可扩展导出为 Markdown、PDF 等格式。
+            </Paragraph>
+          </Collapse.Panel>
+        </Collapse>
+      </Card>
+
+      <Alert
+        style={{ marginTop: 24 }}
+        message="遇到问题？"
+        description="可在生成页面的错误提示中查看详细原因与恢复建议，必要时调整输入或稍后重试。"
+        type="info"
+        showIcon
+      />
+    </div>
+  );
+};
+
+export default HelpPage;

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/src/services/difyApi.ts
+++ b/src/services/difyApi.ts
@@ -1,0 +1,274 @@
+import axios from 'axios';
+
+export const DIFY_API_CONFIG = {
+  baseUrl: '/v1',
+  endpoints: {
+    workflowsRun: '/workflows/run',
+    completionMessages: '/completion-messages',
+    chatMessages: '/chat-messages'
+  },
+  defaultUser: 'paper-generator-ui'
+} as const;
+
+type WorkflowInputs = Record<string, unknown>;
+
+type WorkflowResponse = {
+  id?: string;
+  status?: string;
+  message?: string;
+  outputs?: Record<string, unknown> | null;
+  result?: string;
+  data?: {
+    outputs?: Record<string, unknown> | null;
+    result?: string;
+  };
+};
+
+type WorkflowPayload = {
+  inputs: WorkflowInputs;
+  response_mode?: 'blocking' | 'streaming' | 'no_wait' | 'async';
+  user?: string;
+  workflow_id?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export interface GenerateOutlineParams {
+  title: string;
+  major?: string;
+  direction?: string;
+  wordCount?: number;
+  description?: string;
+}
+
+export interface GenerateContentParams {
+  outline: string;
+  wordCount?: number;
+}
+
+const apiClient = axios.create({
+  baseURL: DIFY_API_CONFIG.baseUrl,
+  timeout: 60_000
+});
+
+const createHeaders = (apiKey?: string) => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json'
+  };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return headers;
+};
+
+const runWorkflow = async <T extends WorkflowResponse>(
+  payload: WorkflowPayload,
+  apiKey?: string
+): Promise<T> => {
+  const { data } = await apiClient.post<T>(
+    DIFY_API_CONFIG.endpoints.workflowsRun,
+    {
+      response_mode: 'blocking',
+      user: DIFY_API_CONFIG.defaultUser,
+      ...payload
+    },
+    { headers: createHeaders(apiKey) }
+  );
+  return data;
+};
+
+const extractTextFromOutputs = (outputs?: Record<string, unknown> | null): string | null => {
+  if (!outputs) {
+    return null;
+  }
+  const values = Object.values(outputs);
+  for (const value of values) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+    if (typeof value === 'object' && value !== null) {
+      const maybeText =
+        (typeof (value as { text?: unknown }).text === 'string'
+          ? (value as { text: string }).text
+          : undefined) ??
+        (typeof (value as { answer?: unknown }).answer === 'string'
+          ? (value as { answer: string }).answer
+          : undefined) ??
+        (typeof (value as { result?: unknown }).result === 'string'
+          ? (value as { result: string }).result
+          : undefined) ??
+        (typeof (value as { content?: unknown }).content === 'string'
+          ? (value as { content: string }).content
+          : undefined);
+      if (maybeText) {
+        const trimmed = maybeText.trim();
+        if (trimmed) {
+          return trimmed;
+        }
+      }
+    }
+  }
+  return null;
+};
+
+const parseTextArray = (text: string): string[] => {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map((item) => (typeof item === 'string' ? item.trim() : ''))
+        .filter(Boolean);
+    }
+  } catch (error) {
+    // 不是 JSON 数组，退回到按行解析
+  }
+  return text
+    .split(/\r?\n+/)
+    .map((item) => item.replace(/^[-*•\d\.\s]+/, '').trim())
+    .filter(Boolean);
+};
+
+export const generatePaperOutline = async (
+  params: GenerateOutlineParams,
+  apiKey?: string
+): Promise<string> => {
+  const payload: WorkflowPayload = {
+    inputs: {
+      title: params.title,
+      major: params.major,
+      direction: params.direction,
+      word_count: params.wordCount,
+      description: params.description,
+      task_type: 'outline'
+    }
+  };
+  const response = await runWorkflow(payload, apiKey);
+  const text =
+    extractTextFromOutputs(response.outputs ?? response.data?.outputs ?? null) ??
+    response.result ??
+    response.data?.result ??
+    '';
+  if (!text) {
+    throw new Error('未能从工作流响应中解析到论文大纲，请稍后重试或检查工作流配置。');
+  }
+  return text;
+};
+
+export const fetchTitleSuggestions = async (
+  seedText: string,
+  apiKey?: string
+): Promise<string[]> => {
+  const payload: WorkflowPayload = {
+    inputs: {
+      seed_text: seedText,
+      task_type: 'title_suggestions'
+    }
+  };
+  const response = await runWorkflow(payload, apiKey);
+  const text =
+    extractTextFromOutputs(response.outputs ?? response.data?.outputs ?? null) ??
+    response.result ??
+    response.data?.result ??
+    '';
+  if (!text) {
+    return [];
+  }
+  return parseTextArray(text);
+};
+
+export const generatePaperContent = async (
+  params: GenerateContentParams,
+  apiKey?: string
+): Promise<string> => {
+  const payload: WorkflowPayload = {
+    inputs: {
+      outline: params.outline,
+      word_count: params.wordCount,
+      task_type: 'content'
+    }
+  };
+  const response = await runWorkflow(payload, apiKey);
+  const text =
+    extractTextFromOutputs(response.outputs ?? response.data?.outputs ?? null) ??
+    response.result ??
+    response.data?.result ??
+    '';
+  if (!text) {
+    throw new Error('未能从工作流响应中解析到正文内容，请检查工作流返回格式。');
+  }
+  return text;
+};
+
+export const validateApiKey = async (apiKey: string): Promise<boolean> => {
+  try {
+    const response = await apiClient.post(
+      DIFY_API_CONFIG.endpoints.workflowsRun,
+      {
+        inputs: { ping: 'health_check' },
+        response_mode: 'no_wait',
+        user: DIFY_API_CONFIG.defaultUser
+      },
+      { headers: createHeaders(apiKey) }
+    );
+    return response.status >= 200 && response.status < 300;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      return false;
+    }
+    throw error;
+  }
+};
+
+export const formatErrorMessage = (error: unknown): string => {
+  if (axios.isAxiosError(error)) {
+    if (error.code === 'ECONNABORTED') {
+      return '请求超时，请检查网络状况或稍后重试。';
+    }
+
+    if (!error.response) {
+      return '网络请求失败，请确认已连接至网络并检查代理配置。';
+    }
+
+    const status = error.response.status;
+    const data = error.response.data as
+      | { message?: string; error?: string; detail?: string }
+      | string
+      | undefined;
+    const detail =
+      typeof data === 'string'
+        ? data
+        : data?.message ?? data?.error ?? data?.detail ?? '';
+
+    switch (status) {
+      case 400:
+        return detail || '请求参数有误，请检查输入内容后重试。';
+      case 401:
+        return detail || '鉴权失败，请确认 Dify API Key 是否填写正确。';
+      case 403:
+        return detail || '无权访问所请求的工作流，请确认权限配置。';
+      case 404:
+        return detail || '未找到对应的接口，请确认代理或工作流地址是否正确。';
+      case 429:
+        return detail || '请求过于频繁，请稍后重试或降低调用频率。';
+      case 500:
+        return detail || '服务内部错误，请稍后重试。';
+      case 502:
+      case 503:
+      case 504:
+        return (
+          detail ||
+          '上游服务暂时不可用或超时，请稍后重试，必要时可调整工作流为流式或异步模式。'
+        );
+      default:
+        return detail || `请求失败（状态码：${status}），请稍后再试。`;
+    }
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return '发生未知错误，请稍后重试。';
+};

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,18 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function setupProxy(app) {
+  app.use(
+    '/v1',
+    createProxyMiddleware({
+      target: 'https://api.dify.ai',
+      changeOrigin: true,
+      secure: true,
+      pathRewrite: {
+        '^/v1': '/v1'
+      },
+      logLevel: 'warn',
+      timeout: 10 * 60 * 1000,
+      proxyTimeout: 10 * 60 * 1000
+    })
+  );
+};

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,62 @@
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC',
+    'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+  background-color: #f5f5f5;
+}
+
+.app-layout {
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.app-logo {
+  color: #ffffff !important;
+  margin: 0 !important;
+}
+
+.app-content {
+  padding: 24px;
+}
+
+.app-footer {
+  text-align: center;
+}
+
+.page-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.section-title {
+  margin-top: 32px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.textarea {
+  min-height: 200px;
+}
+
+.result-card {
+  margin-top: 24px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.error-text {
+  color: #ff4d4f;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "types": ["node", "jest"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "scripts", "config"]
+}


### PR DESCRIPTION
## Summary
- scaffold a React + TypeScript interface with routing for the paper generator and help center
- implement outline editing, title suggestions, content generation workflows, and unified Dify API services
- add CRA configuration, proxy setup, global styles, and project documentation

## Testing
- npm test *(fails: react-scripts not found because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0dbed05b883208535626bdeed15fe